### PR TITLE
Improvements / generalizations to spec file

### DIFF
--- a/rpmbuild/libzbxpgsql.spec
+++ b/rpmbuild/libzbxpgsql.spec
@@ -88,6 +88,11 @@ rm -rf $RPM_BUILD_ROOT
 %{_sysconfdir}/%{name}.d/query.conf
 
 %changelog
+* Wed Mar 17 2021 Otheus <otheus+foss@gmail.com> 1.1.0-2
+- Check for Zabbix source directory and pg_config variables
+- Require query.conf to be in source tree. It's not clear which 
+  directory this file should be pulled from, since a spec file
+  should define all sources within itself.
 * Sat Aug 20 2016 Ryan Armstrong <ryan@cavaliercoder.com> 1.1.0-1
 - Added configuration file for long custom queries - Rob Brucks
 

--- a/rpmbuild/libzbxpgsql.spec
+++ b/rpmbuild/libzbxpgsql.spec
@@ -1,7 +1,7 @@
 Name        : libzbxpgsql
 Vendor      : cavaliercoder
 Version     : 1.1.0
-Release     : 1
+Release     : 2
 Summary     : PostgreSQL monitoring module for Zabbix
 
 Group       : Applications/Internet

--- a/rpmbuild/libzbxpgsql.spec
+++ b/rpmbuild/libzbxpgsql.spec
@@ -10,6 +10,7 @@ URL         : https://github.com/cavaliercoder/libzbxpgsql
 
 # Zabbix sources (Customized)
 Source0     : %{name}-%{version}.tar.gz
+Source1     : query.conf
 
 Buildroot   : %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
@@ -53,6 +54,9 @@ test -f configure  || ./autogen.sh
 # fix up some lib64 issues
 sed -i.orig -e 's|_LIBDIR=/usr/lib|_LIBDIR=%{_libdir}|g' configure
 
+# fix up errant documentation in config file (easier than patching)
+sed -i.orig -e 's|pg_query\.|pg.query.|' conf/libzbxpgsql.conf
+
 %build
 # Configure and compile sources into $RPM_BUILD_ROOT
 %configure --enable-dependency-tracking --with-zabbix="$ZABBIX_SOURCE"
@@ -72,7 +76,7 @@ mv $RPM_BUILD_ROOT%{_libdir}/%{name}.so $RPM_BUILD_ROOT%{moddir}/modules/%{name}
 install -dm 755 $RPM_BUILD_ROOT%{_sysconfdir}/zabbix/zabbix_agentd.d
 echo "LoadModule=libzbxpgsql.so" > $RPM_BUILD_ROOT%{_sysconfdir}/zabbix/zabbix_agentd.d/%{name}.conf
 install -dm 755 $RPM_BUILD_ROOT%{_sysconfdir}/%{name}.d
-install -m 644 query.conf $RPM_BUILD_ROOT%{_sysconfdir}/%{name}.d/
+install -m 644 %{S:1} $RPM_BUILD_ROOT%{_sysconfdir}/%{name}.d/
 
 %clean
 # Clean out the build root


### PR DESCRIPTION
These changes are documented in the changelog:
* PG_CONFIG and ZABBIX_SOURCE environment variables are checked and if the defaults don't work, exits in the %setup stage.
* Fixes typos in the configuration file (pg_query was replaced with pg.query at some point)
* Release number